### PR TITLE
Make slots and rooms sortable via drag and drop

### DIFF
--- a/src/Application/Entities/Room.cs
+++ b/src/Application/Entities/Room.cs
@@ -3,6 +3,7 @@ namespace OpenSpace.Application.Entities;
 public record Room(
     string Id,
     string Name,
+    int OrderNumber,
     int? Seats = null,
     ICollection<string>? Capabilities = null)
 {

--- a/src/Application/Entities/Slot.cs
+++ b/src/Application/Entities/Slot.cs
@@ -5,5 +5,6 @@ namespace OpenSpace.Application.Entities;
 public record Slot(
     string Id,
     string Name,
+    int OrderNumber,
     string? Time = null,
     bool? IsPlanable = true);

--- a/src/WebApi/Controllers/SessionRoomsController.cs
+++ b/src/WebApi/Controllers/SessionRoomsController.cs
@@ -24,9 +24,12 @@ public class SessionRoomsController : ApiControllerBase
     {
         var session = await _sessionRepository.Get(sessionId);
 
+        var highestOrderNumber = session.Rooms.Count != 0 ? session.Rooms.Max(r => r.OrderNumber) + 1 : 0;
+
         var room = new Room(
             Guid.NewGuid().ToString(),
             string.IsNullOrWhiteSpace(request.Name) ? "Room " + (session.Rooms.Count + 1) : request.Name,
+            highestOrderNumber,
             request.Seats ?? 0,
             new List<string>());
 

--- a/src/WebApi/Controllers/SessionSlotsController.cs
+++ b/src/WebApi/Controllers/SessionSlotsController.cs
@@ -25,9 +25,12 @@ public class SessionSlotsController : ApiControllerBase
     {
         var session = await _sessionRepository.Get(sessionId);
 
+        var highestOrderNumber = session.Slots.Count != 0 ? session.Slots.Max(s => s.OrderNumber) + 1 : 0;
+
         var slot = new Slot(
             Guid.NewGuid().ToString(),
-            string.IsNullOrWhiteSpace(request.Name) ? "Slot " + (session.Slots.Count + 1) : request.Name);
+            string.IsNullOrWhiteSpace(request.Name) ? "Slot " + (session.Slots.Count + 1) : request.Name,
+            highestOrderNumber);
 
         await _sessionRepository.Update(sessionId, (session) => session.Slots.Add(slot));
 

--- a/src/Website/src/app/session/session.component.html
+++ b/src/Website/src/app/session/session.component.html
@@ -43,7 +43,7 @@
 
         <tbody>
           <tr class="table-row" *ngFor="let slot of slots" id="{{ slot.id }}">
-            <td class="table-cell" (dblclick)="showModal($event, 'slot', slot)" appEditButton>
+            <td class="table-cell draggable-slot-space" (dblclick)="showModal($event, 'slot', slot)" appEditButton>
               <span>{{ slot.name }}</span>
               <a (click)="showModal($event, 'slot', slot)">
                 <fa-icon [icon]="['fas', 'edit']" class="pull-right edit-button"></fa-icon>

--- a/src/Website/src/app/session/session.component.html
+++ b/src/Website/src/app/session/session.component.html
@@ -30,7 +30,7 @@
           <tr class="table-row">
             <td class="table-cell"></td>
 
-            <td *ngFor="let room of rooms" class="table-cell" id="{{ room.id }}" (dblclick)="showModal($event, 'room', room)" appEditButton>
+            <td *ngFor="let room of rooms; let i = index" class="table-cell draggable-room-space" id="{{ room.id }}" [attr.display-order-number]="i" (dblclick)="showModal($event, 'room', room)" appEditButton>
               <span>{{ room.name }}</span>
               <a (click)="showModal($event, 'room', room)">
                 <fa-icon [icon]="['fas', 'edit']" class="pull-right edit-button"></fa-icon>

--- a/src/Website/src/app/session/session.component.html
+++ b/src/Website/src/app/session/session.component.html
@@ -30,7 +30,7 @@
           <tr class="table-row">
             <td class="table-cell"></td>
 
-            <td *ngFor="let room of rooms; let i = index" class="table-cell draggable-room-space" id="{{ room.id }}" [attr.display-order-number]="i" (dblclick)="showModal($event, 'room', room)" appEditButton>
+            <td *ngFor="let room of rooms" class="table-cell draggable-room-space" id="{{ room.id }}" (dblclick)="showModal($event, 'room', room)" appEditButton>
               <span>{{ room.name }}</span>
               <a (click)="showModal($event, 'room', room)">
                 <fa-icon [icon]="['fas', 'edit']" class="pull-right edit-button"></fa-icon>

--- a/src/Website/src/app/session/session.service.ts
+++ b/src/Website/src/app/session/session.service.ts
@@ -64,7 +64,7 @@ export class SessionService {
   ) {}
 
   public getSortedSlots(slots: Slot[]) {
-    return slots.sort((a, b) => a.time?.localeCompare(b.time ?? '') || a.name.localeCompare(b.name));
+    return slots.sort((a, b) => a.orderNumber - b.orderNumber);
   }
 
   public getSortedRooms(rooms: Room[]) {

--- a/src/Website/src/app/session/session.service.ts
+++ b/src/Website/src/app/session/session.service.ts
@@ -68,7 +68,7 @@ export class SessionService {
   }
 
   public getSortedRooms(rooms: Room[]) {
-    return rooms.sort((a, b) => ((a.seats || 0) > (b.seats || 0) ? -1 : 1 || a.name.localeCompare(b.name)));
+    return rooms.sort((a, b) => a.orderNumber - b.orderNumber);
   }
 
   public getSlotsOfTopic(slots: Slot[], topic: Topic) {

--- a/src/Website/src/app/shared/services/api/model/room.ts
+++ b/src/Website/src/app/shared/services/api/model/room.ts
@@ -14,6 +14,7 @@
 export interface Room { 
     id: string;
     name: string;
+    orderNumber: number;
     seats?: number | null;
     capabilities: Array<string>;
 }

--- a/src/Website/src/app/shared/services/api/model/slot.ts
+++ b/src/Website/src/app/shared/services/api/model/slot.ts
@@ -14,6 +14,7 @@
 export interface Slot { 
     id: string;
     name: string;
+    orderNumber: number;
     time?: string | null;
     isPlanable?: boolean | null;
 }

--- a/src/Website/src/styles.css
+++ b/src/Website/src/styles.css
@@ -32,6 +32,10 @@
   background-color: #eaffea;
 }
 
+.dropable-slot-space {
+  background-color: #eaffea;
+}
+
 .drop-target {
   background-color: lightyellow;
 }

--- a/src/Website/src/styles.css
+++ b/src/Website/src/styles.css
@@ -28,6 +28,10 @@
   background-color: #eaffea;
 }
 
+.dropable-room-space {
+  background-color: #eaffea;
+}
+
 .drop-target {
   background-color: lightyellow;
 }


### PR DESCRIPTION
In this PR, I have implemented a potential solution for making slots and rooms sortable based on #13.

The changes can be summarized as follows:
- Add an `int OrderNumber` property for the `Slot` and `Room` entities, respectively.
- Create additional event handlers with interact.js to accommodate the drag-and-drop functionality.
- Update the target and source `Slot` and `Room`, respectively, via switching the corresponding `OrderNumber` property.

Please note:
- When a new `Slot` or `Room` is created in the backend, the value of `OrderNumber` will be set to the maximum number of all existing slots and rooms plus one, respectively.

Potential improvements:
- The `OrderNumber` may be shown and edited in the room and slot modal, respectively. 